### PR TITLE
(fix) Bump spring boot started web to fix high vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>3.3.11</version>
+            <version>3.3.13</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Description of changes
- This vulnerability has been identified https://app.snyk.io/org/legal-aid-agency/project/42ae4827-0612-4c1b-9b97-e8e6a9895c25#issue-SNYK-JAVA-ORGAPACHETOMCATEMBED-10365122
- To resolve, org.springframework.boot.spring-boot-starter-web has been bumped to 3.3.13 as this will include the latest version of org.apache.tomcat.embed:tomcat-embed-core. This package is responsible for the vulnerability and the upgrade of to spring boot start web bumps embed core from 10.1.20 to 10.1.42

## Evidence
Before
![image](https://github.com/user-attachments/assets/2a3c541b-c832-4751-9426-a1e33edb72f0)




## Checklist
Before you ask people to review this PR:

- [ ] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] Tests and linter checks are passing
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.