### PR TITLE
LPF-1054: Ensure automated bump of project version is a signed commit

### DIFF
--- a/.github/workflows/deploy-new-package.yml
+++ b/.github/workflows/deploy-new-package.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - main
+      - feature/lpf-1054
 
 jobs:
   feature_branch:
-    if: github.ref == 'refs/heads/main'
+#    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: maven-release
 

--- a/.github/workflows/deploy-new-package.yml
+++ b/.github/workflows/deploy-new-package.yml
@@ -4,11 +4,10 @@ on:
   push:
     branches:
       - main
-      - feature/lpf-1054
 
 jobs:
   feature_branch:
-#    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: maven-release
 

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -14,6 +14,14 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Set up SSH signing key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.OPENAPI_SIGNING_SSH }}" > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key  
+          ssh-keygen -y -f ~/.ssh/signing_key > ~/.ssh/signing_key.pub
+          chmod 644 ~/.ssh/signing_key.pub
+
       - name: Configure Git login for tags
           # Mandatory for version creation
         run: |
@@ -24,14 +32,6 @@ jobs:
           git config --global commit.gpgsign true
 
         shell: bash
-
-      - name: Set up SSH signing key
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.OPENAPI_SIGNING_SSH }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key  
-          ssh-keygen -y -f ~/.ssh/signing_key > ~/.ssh/signing_key.pub
-          chmod 644 ~/.ssh/signing_key.pub
 
       - name: Increment version
         run: |

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -25,15 +25,16 @@ jobs:
 
         shell: bash
 
-
       - name: Set up SSH signing key
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.OPENAPI_SSH }}" > ~/.ssh/bot_signing_key
-          chmod 600 ~/.ssh/bot_signing_key
+          chmod 600 ~/.ssh/bot_signing_key  
+          ssh-keygen -y -f ~/.ssh/bot_signing_key > ~/.ssh/bot_signing_key.pub
+          chmod 644 ~/.ssh/bot_signing_key.pub
 
       - name: Increment version
-#         testing signed commits
+      #         testing signed commits
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
@@ -44,3 +45,8 @@ jobs:
           git add pom.xml
           git commit -S -m "chore: bump version to $NEW VERSION [skip ci]"
           git push origin HEAD
+
+      - name: Clean up SSH signing key
+        if: always()
+        run: |
+          rm -f ~/.ssh/bot_signing_key ~/.ssh/bot_signing_key.pub

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Configure Git login for tags
           # Mandatory for version creation
         run: |
+          git config user.name "github-actions[bot]"
           git config user.email "${{ secrets.OPENAPI_SIGNING_SSH_USER }}"    
           git config --global gpg.format ssh
           git config --global user.signingkey ~/.ssh/signing_key
@@ -27,13 +28,12 @@ jobs:
       - name: Set up SSH signing key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.OPENAPI_SSH }}" > ~/.ssh/signing_key
+          echo "${{ secrets.OPENAPI_SIGNING_SSH }}" > ~/.ssh/signing_key
           chmod 600 ~/.ssh/signing_key  
           ssh-keygen -y -f ~/.ssh/signing_key > ~/.ssh/signing_key.pub
           chmod 644 ~/.ssh/signing_key.pub
 
       - name: Increment version
-      #         testing signed commits
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -30,5 +30,5 @@ jobs:
           mvn versions:set -DnewVersion=${NEW_VERSION}
           mvn versions:commit
           git add pom.xml
-          git commit -m "chore: bump version to $NEW VERSION [skip ci]"
+          git commit -S -m "chore: bump version to $NEW VERSION [skip ci]"
           git push origin HEAD

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -18,8 +18,19 @@ jobs:
           # Mandatory for version creation
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "github-actions[bot]@users.noreply.github.com"          
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/signing_key
+          git config --global commit.gpgsign true
+
         shell: bash
+
+
+      - name: Set up SSH signing key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.OPENAPI_SSH }}" > ~/.ssh/bot_signing_key
+          chmod 600 ~/.ssh/bot_signing_key
 
       - name: Increment version
 #         testing signed commits

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -17,8 +17,7 @@ jobs:
       - name: Configure Git login for tags
           # Mandatory for version creation
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"    
+          git config user.email "${{ secrets.OPENAPI_SIGNING_SSH_USER }}"    
           git config --global gpg.format ssh
           git config --global user.signingkey ~/.ssh/signing_key
           git config --global commit.gpgsign true

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -18,7 +18,7 @@ jobs:
           # Mandatory for version creation
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"          
+          git config user.email "github-actions[bot]@users.noreply.github.com"    
           git config --global gpg.format ssh
           git config --global user.signingkey ~/.ssh/signing_key
           git config --global commit.gpgsign true
@@ -28,10 +28,10 @@ jobs:
       - name: Set up SSH signing key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.OPENAPI_SSH }}" > ~/.ssh/bot_signing_key
-          chmod 600 ~/.ssh/bot_signing_key  
-          ssh-keygen -y -f ~/.ssh/bot_signing_key > ~/.ssh/bot_signing_key.pub
-          chmod 644 ~/.ssh/bot_signing_key.pub
+          echo "${{ secrets.OPENAPI_SSH }}" > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key  
+          ssh-keygen -y -f ~/.ssh/signing_key > ~/.ssh/signing_key.pub
+          chmod 644 ~/.ssh/signing_key.pub
 
       - name: Increment version
       #         testing signed commits
@@ -43,10 +43,10 @@ jobs:
           mvn versions:set -DnewVersion=${NEW_VERSION}
           mvn versions:commit
           git add pom.xml
-          git commit -S -m "chore: bump version to $NEW VERSION [skip ci]"
+          git commit -S -m "chore: bump version to ${NEW_VERSION} [skip ci]"
           git push origin HEAD
 
       - name: Clean up SSH signing key
         if: always()
         run: |
-          rm -f ~/.ssh/bot_signing_key ~/.ssh/bot_signing_key.pub
+          rm -f ~/.ssh/signing_key ~/.ssh/signing_key.pub

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -22,6 +22,7 @@ jobs:
         shell: bash
 
       - name: Increment version
+#         testing signed commits
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ TBD - awaiting hosting implementation
 
 ## Versioning
 On creation of a pull request, the `increment version` workflow will run, and automatically increment the patch version number by one. 
+Commits are signed using an SSH key. The private key is stored as a secret in GitHub and should be maintained by a current member of the team.
 
 This is to support correct values for package deployment and tag creation.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.12</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.13</version>
+    <version>0.0.14</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.12</version>
+    <version>0.0.13</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.14</version>
+    <version>0.0.6</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
JIRA: [LPF-1054](https://dsdmoj.atlassian.net/browse/LPF-1054)

## Description of changes
- Incrementing of the openapi version number is being done by an automated workflow. However, this repository expects all commits to be signed, these automated commits were not signed, so PR's included a manual squash step to remove the unsigned commit
- An ssh key has been added to the repository to ensure automated commits are signed. 
- It was agreed to use an account associated with the team, rather than a bot account, given the minimal impact of the automated commit and ease of monitoring and rotation of ssh key, if someone leaves the team/organisation.

## Evidence
Automated commits are now signed
<img width="1316" height="78" alt="image" src="https://github.com/user-attachments/assets/42fe07cc-6887-4a4b-a441-5e0105b92dab" />

## Checklist
Before you ask people to review this PR:

- [x] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [x] Tests and linter checks are passing
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.

[LPF-1054]: https://dsdmoj.atlassian.net/browse/LPF-1054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ