### PR TITLE
LPF-1082 - tweak - avoid it defining endpoint as wrong type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,17 @@
                             </inputSpec>
                             <typeMappings>
                                 <typeMapping>string+binary=StreamingResponseBody</typeMapping>
+                                <typeMapping>string+csv=InputStreamResource</typeMapping>
                             </typeMappings>
                             <importMappings>
                                 <importMapping>StreamingResponseBody=org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody</importMapping>
+                                <importMapping>InputStreamResource=org.springframework.core.io.InputStreamResource</importMapping>
                             </importMappings>
                             <generatorName>spring</generatorName>
                             <apiPackage>uk.gov.laa.gpfd.api</apiPackage>
                             <modelPackage>uk.gov.laa.gpfd.model</modelPackage>
                             <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
+                            <verbose>true</verbose>
                             <configOptions>
                                 <library>spring-boot</library>
                                 <oas3>false</oas3>

--- a/src/main/resources/swagger.yml
+++ b/src/main/resources/swagger.yml
@@ -358,7 +358,7 @@ paths:
             application/octet-stream:
               schema:
                 type: string
-                format: binary
+                format: csv
                 example: |
                   "date","amount","description"
                   "2023-01-01","1000","Legal Aid Case Payment"


### PR DESCRIPTION
JIRA: [LPF-1083](https://dsdmoj.atlassian.net/browse/LPF-1083)

## Description of changes
- New endpoint was being generated as a StreamingBodyResponse, instead of an InputStreamResource
- Bit of a temporary workaround, since this is a temporary endpoint. The format csv isn't strictly correct, but the only consumer of the API is us so the swagger being slightly inaccurate is acceptable for now in return for our code being generated in a way that makes implementation easier.

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist
Before you ask people to review this PR:

- [ ] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] Tests and linter checks are passing
- [ ] Documentation README.md & Confluence have been updated
- [ ] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [ ] Clean commit history
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.