### PR TITLE
LPF-716 - Update URLs to align with RESTFul standard

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,4 +2,10 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  SNYK-JAVA-ORGAPACHETOMCATEMBED-15989820:
+      - '*':
+          reason: >-
+             Transitive from Spring 4. Will wait for updates to bring in version bump
+          expires: 2026-05-14T00:00:00.000Z
+          created: 2026-04-14T00:00:00.000Z
 patch: {}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.31</version>
+    <version>0.0.32</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.32</version>
+    <version>0.0.33</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.33</version>
+    <version>0.0.31</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/src/main/resources/swagger.yml
+++ b/src/main/resources/swagger.yml
@@ -229,7 +229,7 @@ paths:
 
   /reports/{id}/csv:
     get:
-      operationId: downloadCsv
+      operationId: getCsvById
       tags:
         - Reports
       summary: Download Report as CSV Stream

--- a/src/main/resources/swagger.yml
+++ b/src/main/resources/swagger.yml
@@ -227,8 +227,9 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /csv/{id}:
+  /reports/{id}/csv:
     get:
+      operationId: downloadCsv
       tags:
         - Reports
       summary: Download Report as CSV Stream
@@ -268,7 +269,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /excel/{id}:
+  /reports/{id}/excel:
     get:
       tags:
         - Reports


### PR DESCRIPTION
JIRA: [LPF-716](https://dsdmoj.atlassian.net/browse/LPF-716)

## Description of changes
We wanted to make the reports endpoints restful so that instead of excel/{id}, we are calling reports/{id}/excel, for example.
Changes in this PR:

- RESTful resource organisation: The endpoints are now properly nested under the /reports resource:
```
/reports/{id}/csv (instead of /csv/{id})
/reports/{id}/excel (instead of /excel/{id})
/reports/{id}/file (for S3 downloads)
/reports/{id} (report metadata)
/reports (list all reports)
```
which means we can remove the dedicated ExcelApi and CsvApi.

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist
Before you ask people to review this PR:

- [X] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [ ] Tests and linter checks are passing
- [ ] Documentation README.md & Confluence have been updated
- [X] TODOs, commented code and print traces have been removed
- [ ] Any dependant changes have been merged in downstream modules
- [X] Clean commit history
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.

[LPF-716]: https://dsdmoj.atlassian.net/browse/LPF-716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ