### PR TITLE
LPF-1127 - ensure all three downloads use same response type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.32</version>
+    <version>0.0.33</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.33</version>
+    <version>0.0.33-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,9 @@
                             </inputSpec>
                             <typeMappings>
                                 <typeMapping>string+binary=StreamingResponseBody</typeMapping>
-                                <typeMapping>string+csv=InputStreamResource</typeMapping>
                             </typeMappings>
                             <importMappings>
                                 <importMapping>StreamingResponseBody=org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody</importMapping>
-                                <importMapping>InputStreamResource=org.springframework.core.io.InputStreamResource</importMapping>
                             </importMappings>
                             <generatorName>spring</generatorName>
                             <apiPackage>uk.gov.laa.gpfd.api</apiPackage>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.44-SNAPSHOT</version>
+    <version>0.0.44</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,9 @@
                             </inputSpec>
                             <typeMappings>
                                 <typeMapping>string+binary=StreamingResponseBody</typeMapping>
-                                <typeMapping>string+csv=InputStreamResource</typeMapping>
                             </typeMappings>
                             <importMappings>
                                 <importMapping>StreamingResponseBody=org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody</importMapping>
-                                <importMapping>InputStreamResource=org.springframework.core.io.InputStreamResource</importMapping>
                             </importMappings>
                             <generatorName>spring</generatorName>
                             <apiPackage>uk.gov.laa.gpfd.api</apiPackage>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.43</version>
+    <version>0.0.44-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/src/main/resources/swagger.yml
+++ b/src/main/resources/swagger.yml
@@ -360,7 +360,7 @@ paths:
             application/octet-stream:
               schema:
                 type: string
-                format: csv
+                format: binary
                 example: |
                   "date","amount","description"
                   "2023-01-01","1000","Legal Aid Case Payment"

--- a/src/main/resources/swagger.yml
+++ b/src/main/resources/swagger.yml
@@ -366,7 +366,7 @@ paths:
             application/octet-stream:
               schema:
                 type: string
-                format: csv
+                format: binary
                 example: |
                   "date","amount","description"
                   "2023-01-01","1000","Legal Aid Case Payment"


### PR DESCRIPTION
JIRA: [LPF-1127](https://dsdmoj.atlassian.net/browse/LPF-1127)

## Description of changes
- For report tracking, we want to track when the stream on the server is finished without error (note this is different to the download on the client finishing)
- To do this, the S3 download needs to use a `StreamingResponseBody` rather than the current usage of `InputStreamResource`, so we can hook into the process properly.

## Evidence
N/A

## Checklist
Before you ask people to review this PR:

- [x] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [x] Tests and linter checks are passing
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.

[LPF-1127]: https://dsdmoj.atlassian.net/browse/LPF-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ