### PR TITLE
fix(LPF-9999): Fix after openapi-generator update changed default resolving behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.laa</groupId>
     <artifactId>payforlegalaid-openapi</artifactId>
-    <version>0.0.37</version>
+    <version>0.0.38</version>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/src/main/resources/swagger.yml
+++ b/src/main/resources/swagger.yml
@@ -62,6 +62,7 @@ components:
       content:
         application/json:
           schema:
+            title: ReportsGet401Response
             type: object
             properties:
               error:
@@ -72,6 +73,7 @@ components:
       content:
         application/json:
           schema:
+            title: ReportsGet404Response
             type: object
             properties:
               error:
@@ -82,6 +84,7 @@ components:
       content:
         application/json:
           schema:
+            title: ReportsGet500Response
             type: object
             properties:
               error:
@@ -92,6 +95,7 @@ components:
       content:
         application/json:
           schema:
+            title: ReportsGet400Response
             type: object
             properties:
               error:
@@ -102,6 +106,7 @@ components:
       content:
         application/json:
           schema:
+            title: GetReportDownloadById403Response
             type: object
             properties:
               error:
@@ -112,6 +117,7 @@ components:
       content:
         application/json:
           schema:
+            title: GetReportDownloadById501Response
             type: object
             properties:
               error:


### PR DESCRIPTION
JIRA: [JIRA ticket number](https://dsdmoj.atlassian.net/browse/LPF-XXX)

## Description of changes
- Openapi generator update from Dependabot the other day changed how it handles duplicate generations - it was squashing "identical" objects together. This then stopped our code compiling 
- Giving them a title forces them to generate separately.
## Evidence
Before fix:
<img width="425" height="216" alt="image" src="https://github.com/user-attachments/assets/fd4c5557-ed61-4106-a3e2-cff2e5f1e475" />

After fix:
<img width="425" height="281" alt="image" src="https://github.com/user-attachments/assets/0869de1f-d782-4012-bb49-305835b0d78a" />

## Checklist
Before you ask people to review this PR:

- [x] Title follows the naming {Type}: {TICKET-NUMBER}-{brief-description}. All fields should be in the branch name. Type is the type of change: feature, documentation, bugfix...
- [x] Tests and linter checks are passing
- [x] Documentation README.md & Confluence have been updated
- [x] TODOs, commented code and print traces have been removed
- [x] Any dependant changes have been merged in downstream modules
- [x] Clean commit history
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.